### PR TITLE
[Y4] Add Matcher  and small adjusts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ To get started with running the project locally, follow these steps:
 
    The server will be running at `http://localhost:3000`.
 
+## Custom Matchers for RSpec
+
+A custom RSpec matcher has been created to facilitate JSON response comparisons in this project.
+
+### Usage
+
+To use the custom matcher, you can do the following in your specs:
+
+```ruby
+expect(actual_response).to match_response(expected_response)
+```
+
+If you need to specify a serializer, you can do so like this:
+
+```ruby
+expect(actual_response).to match_response(expected_response).with_serializer(MySerializer)
+```
+
 ## GitHub Workflow for RSpec
 
 This project includes a GitHub Actions workflow that runs RSpec tests for each pull request and push to the master branch. The workflow is defined in the `.github/workflows/rspec.yml` file. It ensures that all tests pass before any changes are merged into the master branch, maintaining the integrity of the codebase.

--- a/app/commands/pay_rates/calculate_payment.rb
+++ b/app/commands/pay_rates/calculate_payment.rb
@@ -1,5 +1,19 @@
 module Commands
   module PayRates
+    # Calculates the payment for a teacher based on the number of clients in the class.
+    #
+    # Examples:
+    #
+    # 1. base_rate_per_client is $5.00 and there is one PayRateBonus with a
+    #    rate_per_client of $3.00, min_client_count of 25, and no max_client_count.
+    #    - If there are 30 clients: 5.00 * 30 + (30 - 25) * 3.00 = $165.00
+    #    - If there are 15 clients: 5.00 * 15 = $75.00
+    #
+    # 2. base_rate_per_client is $5.00 and there is one PayRateBonus with a
+    #    rate_per_client of $3.00, min_client_count of 25, and max_client_count of 40.
+    #    - If there are 30 clients: 5.00 * 30 + (30 - 25) * 3.00 = $165.00
+    #    - If there are 45 clients: 5.00 * 45 + (40 - 25) * 3.00 = $270.00
+    #
     class CalculatePayment < Base
       def initialize(pay_rate, client_count)
         @pay_rate = pay_rate
@@ -7,10 +21,7 @@ module Commands
       end
 
       def execute
-        payment = base_payment
-        payment += bonus_payment if eligible_for_bonus?
-
-        payment
+        base_payment + bonus_payment
       end
 
       private
@@ -21,15 +32,19 @@ module Commands
         pay_rate.base_rate_per_client * client_count
       end
 
+      def bonus_payment
+        return 0 unless eligible_for_bonus?
+
+        eligible_clients * rate_per_client
+      end
+
       def eligible_for_bonus?
         rate_per_client.present? && client_count >= min_client_count
       end
 
-      def bonus_payment
-        max_clients = [max_client_count, client_count].compact.min
-        eligible_clients = max_clients - min_client_count
-
-        eligible_clients * rate_per_client
+      def eligible_clients
+        max_clinets = [max_client_count, client_count].compact.min
+        max_clinets - min_client_count
       end
 
       def min_client_count

--- a/app/controllers/pay_rates/payments_controller.rb
+++ b/app/controllers/pay_rates/payments_controller.rb
@@ -1,6 +1,6 @@
 module PayRates
   class PaymentsController < ApplicationController
-    before_action :validate_client_count, only: :show
+    before_action :validate_params, only: :show
 
     def show
       pay_rate = PayRate.find(params[:pay_rate_id])
@@ -13,15 +13,15 @@ module PayRates
 
     private
 
-    def validate_client_count
-      if params[:clients].blank? || !valid_client_count?(params[:clients])
+    def validate_params
+      if params[:clients].blank? || !integer?(params[:clients])
         render json: { error: '"clients" parameter must be a valid integer' }, status: :unprocessable_entity
       else
         @client_count = params[:clients].to_i
       end
     end
 
-    def valid_client_count?(client_count)
+    def integer?(client_count)
       Integer(client_count) rescue false
     end
   end

--- a/spec/models/pay_rate_bonus_spec.rb
+++ b/spec/models/pay_rate_bonus_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PayRateBonus, type: :model do
   subject { build(:pay_rate_bonus) }
 
   describe 'associations' do
-    it { should belong_to(:pay_rate).optional }
+    it { is_expected.to belong_to(:pay_rate).optional }
   end
 
   describe 'validations' do

--- a/spec/models/pay_rate_spec.rb
+++ b/spec/models/pay_rate_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PayRate, type: :model do
   subject { create(:pay_rate) }
 
   describe 'associations' do
-    it { should have_one(:pay_rate_bonus).dependent(:destroy) }
+    it { is_expected.to have_one(:pay_rate_bonus).dependent(:destroy) }
   end
 
   describe 'validations' do
@@ -13,6 +13,6 @@ RSpec.describe PayRate, type: :model do
   end
 
   describe 'nested attributes' do
-    it { should accept_nested_attributes_for(:pay_rate_bonus).allow_destroy(true) }
+    it { is_expected.to accept_nested_attributes_for(:pay_rate_bonus).allow_destroy(true) }
   end
 end

--- a/spec/requests/pay_rates/create_spec.rb
+++ b/spec/requests/pay_rates/create_spec.rb
@@ -9,11 +9,8 @@ RSpec.describe 'POST /pay_rates', type: :request do
   it 'creates a new pay rate without bonus' do
     expect { request }.to change(PayRate, :count).by(1)
 
-    # TODO: We can create a matcher for this kind of response
-    expected_response = PayRateSerializer.new(PayRate.last).as_json
-
     expect(response).to have_http_status(:created)
-    expect(response.body).to eq(expected_response.to_json)
+    expect(response.body).to match_response(PayRate.last)
   end
 
   context 'with nested attributes' do
@@ -24,10 +21,8 @@ RSpec.describe 'POST /pay_rates', type: :request do
     it 'creates a new pay rate with bonus' do
       expect { request }.to change(PayRate, :count).by(1)
 
-      expected_response = PayRateSerializer.new(PayRate.last).as_json
-
       expect(response).to have_http_status(:created)
-      expect(response.body).to eq(expected_response.to_json)
+      expect(response.body).to match_response(PayRate.last)
     end
   end
 

--- a/spec/support/matchers/response_matchers.rb
+++ b/spec/support/matchers/response_matchers.rb
@@ -1,0 +1,43 @@
+# Custom RSpec matcher to compare JSON responses.
+# Usage:
+# expect(actual_response).to match_response(expected_response)
+# You can also specify a serializer if needed:
+# expect(actual_response).to match_response(expected_response).with_serializer(MySerializer)
+
+RSpec::Matchers.define :match_response do |expected|
+  match do |actual|
+    @actual = JSON.parse(actual)
+    @expected = serialize(expected)
+    @actual == @expected
+  end
+
+  chain :with_serializer do |serializer|
+    @serializer = serializer
+  end
+
+  diffable
+
+  private
+
+  def serialize(object)
+    if object.is_a?(Array)
+      object.map { |item| serialize_item(item) }
+    else
+      serialize_item(object)
+    end
+  end
+
+  def serialize_item(item)
+    if item.respond_to?(:serializable_hash)
+      serializer_class = @serializer || ActiveModel::Serializer.serializer_for(item)
+      raise "No serializer found for #{item.class}" unless serializer_class
+
+      serializer_instance = serializer_class.new(item)
+      serializer_instance.as_json.deep_stringify_keys
+    elsif item.is_a?(Hash)
+      item.deep_stringify_keys
+    else
+      item
+    end
+  end
+end


### PR DESCRIPTION
## Description

- Introduces match_response RSpec matcher for comparing JSON responses.
  - Allows optional serializer specification for expected responses.
  - Provides clear diffs for mismatched responses.

## Usage Example
```ruby
expect(actual_response).to match_response(expected_response)
expect(actual_response).to match_response(expected_response).with_serializer(MySerializer)
```

## Extra
- Some small adjusts on the app, improving variable names and code organization.